### PR TITLE
feat!: Split the data flag implemenation into -d and -f

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,11 @@ $ easyrpc c -a localhost:12345 -r example.package.Service.Method -d '{"msg":"hel
 $ echo '{"msg":"hello"}' | easyrpc c -a localhost:12345 -r example.package.Service.Method -d -
 
 # Reading the data from file
-$ easyrpc c -a localhost:12345 -r example.package.Service.Method -d @~/some/path/request.json
+$ easyrpc c -a localhost:12345 -r example.package.Service.Method -f ~/some/path/request.json
 ```
+
+> [!NOTE]
+> Only one of `-d` or `-f` flags may be set at the same time. They are mutually exclusive.
 
 ### Request data preparation
 
@@ -219,10 +222,10 @@ default will be used instead.
 $ easyrpc c example.package.Service.Method -e
 
 # Pass an existing request and then edit that request before call.
-$ easyrpc c example.package.Service.Method -d request.json -e
+$ easyrpc c example.package.Service.Method -f request.json -e
 
 # Edit also works with request command which helps with request preparation for future reuse.
-$ easyrpc r example.package.Service.Method -d request.json -e -o modified_request.json
+$ easyrpc r example.package.Service.Method -f request.json -e -o modified_request.json
 
 # If you supply more than one message for a client streaming method, each message will be opened for editing in
 # sequence.

--- a/internal/app/call.go
+++ b/internal/app/call.go
@@ -20,7 +20,7 @@ func (a *App) registerCallCmd() {
 		RunE:              callCmd.Run,
 	}
 
-	flags.RegisterDataFlag(cmd)
+	flags.RegisterDataAndFileFlags(cmd)
 	flags.RegisterEditFlag(cmd)
 
 	a.cmd.AddCommand(cmd)

--- a/internal/app/request.go
+++ b/internal/app/request.go
@@ -20,9 +20,9 @@ func (a *App) registerRequestCmd() {
 		RunE:              requestCmd.Run,
 	}
 
+	flags.RegisterDataAndFileFlags(cmd)
 	flags.RegisterEditFlag(cmd)
 	flags.RegisterOutputFlag(cmd)
-	flags.RegisterDataFlag(cmd)
 
 	a.cmd.AddCommand(cmd)
 }

--- a/internal/cmds/call.go
+++ b/internal/cmds/call.go
@@ -46,7 +46,7 @@ func (c *Call) Run(cmd *cobra.Command, args []string) error {
 		return errors.Join(ErrValidation, err)
 	}
 
-	input, err := flags.HandleDataFlag(cmd, c.fs)
+	input, err := flags.HandleDataOrFileFlag(cmd, c.fs)
 	if err != nil {
 		return fmt.Errorf("failed to handle data flag: %w", err)
 	}

--- a/internal/cmds/request.go
+++ b/internal/cmds/request.go
@@ -55,7 +55,7 @@ func (r *Request) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create descriptor source: %w", err)
 	}
 
-	input, err := flags.HandleDataFlag(cmd, r.fs)
+	input, err := flags.HandleDataOrFileFlag(cmd, r.fs)
 	if err != nil {
 		return fmt.Errorf("failed to handle data flag: %w", err)
 	}

--- a/internal/flags/data.go
+++ b/internal/flags/data.go
@@ -2,9 +2,9 @@ package flags
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -12,28 +12,47 @@ import (
 	fsutil "github.com/heartandu/easyrpc/pkg/fs"
 )
 
-// RegisterDataFlag registers the data flag with the provided command.
-// The flag allows the user to specify request data.
-func RegisterDataFlag(cmd *cobra.Command) {
-	cmd.Flags().StringP("data", "d", "", "request data in json format")
+const (
+	dataFlag = "data"
+	fileFlag = "file"
+)
+
+var ErrDataAndFileFlagDisallowed = errors.New("only data or file flag is allowed to be set")
+
+// RegisterDataAndFileFlags registers the data and the file flags with the provided command.
+// The flags allow the user to specify request data by providing raw data string, read the
+// data from stdin or from a file.
+func RegisterDataAndFileFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP(dataFlag, "d", "", "request data in json format (specify \"-\" to read stdin)")
+	cmd.Flags().StringP(fileFlag, "f", "", "file name with request data in json format")
 }
 
-// HandleDataFlag returns an io.ReadCloser for the data specified in the flag.
+// HandleDataOrFileFlag returns an io.ReadCloser for the data specified in the data or the file flag.
 // If the data flag is "-", the data will be read from stdin.
-// If the data flag starts with "@", it opens the file specified in the flag.
-// Otherwise, it returns the provided data string.
-func HandleDataFlag(cmd *cobra.Command, fs afero.Fs) (io.ReadCloser, error) {
-	data, err := cmd.Flags().GetString("data")
+// If the file flag is specified, open the file.
+// If no flag is set, returns the provided data string.
+// If the data flag and the file flag are both set, return an error.
+func HandleDataOrFileFlag(cmd *cobra.Command, fs afero.Fs) (io.ReadCloser, error) {
+	data, err := cmd.Flags().GetString(dataFlag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get data flag: %w", err)
+	}
+
+	filename, err := cmd.Flags().GetString(fileFlag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file flag: %w", err)
+	}
+
+	if data != "" && filename != "" {
+		return nil, ErrDataAndFileFlagDisallowed
 	}
 
 	if data == "-" {
 		return io.NopCloser(cmd.InOrStdin()), nil
 	}
 
-	if strings.HasPrefix(data, "@") {
-		path, err := fsutil.ExpandHome(data[1:])
+	if filename != "" {
+		path, err := fsutil.ExpandHome(filename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand home dir: %w", err)
 		}

--- a/internal/flags/edit.go
+++ b/internal/flags/edit.go
@@ -13,7 +13,7 @@ import (
 // RegisterEditFlag registers the edit flag for a given command.
 // The flag allows the user edit input with a text editor of choice.
 func RegisterEditFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolP("edit", "e", false, "edit the request before printing")
+	cmd.Flags().BoolP("edit", "e", false, "edit the request before printing or calling RPCs")
 }
 
 // HandleEditFlag returns an editor.Editor instance if the edit flag is set. Otherwise it returns nil.

--- a/test/call_test.go
+++ b/test/call_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,10 +14,15 @@ import (
 )
 
 func TestCall(t *testing.T) {
+	const tildeTestFileName = "easyrpc_test_msg.json"
+
 	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
 
 	requestFileName, err := createTempFile(fs, "msg.json", `{"msg":"file test"}`)
 	require.NoError(t, err, "failed to create input file")
+
+	err = createFileAtPath(fs, filepath.Join(homeDir(t), tildeTestFileName), `{"msg":"tilde test"}`)
+	require.NoError(t, err, "failed to create tilde test file")
 
 	reqWithUnknownFileName, err := createTempFile(
 		fs,
@@ -150,8 +156,8 @@ func TestCall(t *testing.T) {
 				"echo.EchoService.Echo",
 				"-a",
 				address(insecureSocket),
-				"-d",
-				"@" + requestFileName,
+				"-f",
+				requestFileName,
 				"-r",
 			},
 			want: []map[string]any{{"msg": "file test"}},
@@ -162,11 +168,23 @@ func TestCall(t *testing.T) {
 				"echo.EchoService.Echo",
 				"-a",
 				address(insecureSocket),
-				"-d",
-				"@" + reqWithUnknownFileName,
+				"-f",
+				reqWithUnknownFileName,
 				"-r",
 			},
 			want: []map[string]any{{"msg": "file with unknown"}},
+		},
+		{
+			name: "data from file with tilde path",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-f",
+				"~/" + tildeTestFileName,
+				"-r",
+			},
+			want: []map[string]any{{"msg": "tilde test"}},
 		},
 		{
 			name: "data from stdin",
@@ -485,6 +503,107 @@ func TestCall(t *testing.T) {
 			}
 
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCall_ErrorCases(t *testing.T) {
+	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "invalid method name",
+			args: []string{
+				"echo.NonExistentService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-d",
+				`{"msg":"test"}`,
+				"-r",
+			},
+			wantErr: "Symbol not found: echo.NonExistentService.Echo",
+		},
+		{
+			name: "missing reflection and proto files",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-d",
+				`{"msg":"test"}`,
+			},
+			wantErr: "at least 1 proto file must be specified, imported all files or reflection used",
+		},
+		{
+			name: "connection refused",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				"localhost:59999",
+				"-r",
+				"-d",
+				`{"msg":"test"}`,
+			},
+			wantErr: "connection refused",
+		},
+		{
+			name: "invalid json in data flag",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-d",
+				`{invalid json}`,
+				"-r",
+			},
+			wantErr: "invalid character 'i' looking for beginning of object key string",
+		},
+		{
+			name: "file not found",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-f",
+				"/nonexistent/file.json",
+				"-r",
+			},
+			wantErr: "file does not exist",
+		},
+		{
+			name: "unknown method without package and service flags",
+			args: []string{
+				"UnknownMethod",
+				"-a",
+				address(insecureSocket),
+				"-r",
+			},
+			wantErr: "Symbol not found: ..UnknownMethod",
+		},
+		{
+			name: "both data and file flags specified",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-d",
+				`{"msg":"test"}`,
+				"-f",
+				"/some/file.json",
+				"-r",
+			},
+			wantErr: "only data or file flag is allowed to be set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := runCall(fs, nil, tt.args...)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
 }

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -6,11 +6,22 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
 
 	"github.com/heartandu/easyrpc/internal/app"
 )
+
+func homeDir(t *testing.T) string {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err, "failed to get home directory")
+
+	return home
+}
 
 func createTempFile(fs afero.Fs, name, contents string) (string, error) {
 	file, err := fs.Create(filepath.Join(afero.GetTempDir(fs, ""), name))
@@ -24,6 +35,25 @@ func createTempFile(fs afero.Fs, name, contents string) (string, error) {
 	}
 
 	return file.Name(), nil
+}
+
+func createFileAtPath(fs afero.Fs, path, contents string) error {
+	dir := filepath.Dir(path)
+	if err := fs.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	file, err := fs.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err = file.WriteString(contents); err != nil {
+		return fmt.Errorf("failed to write contents: %w", err)
+	}
+
+	return nil
 }
 
 func run(fs afero.Fs, input io.Reader, env map[string]string, args ...string) ([]byte, error) {

--- a/test/request_test.go
+++ b/test/request_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,10 +14,15 @@ import (
 )
 
 func TestRequest(t *testing.T) {
+	const tildeTestFileName = "easyrpc_test_msg.json"
+
 	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
 
 	requestFileName, err := createTempFile(fs, "msg.json", `{"msg":"file test"}`)
 	require.NoError(t, err, "failed to create input file")
+
+	err = createFileAtPath(fs, filepath.Join(homeDir(t), tildeTestFileName), `{"msg":"tilde test"}`)
+	require.NoError(t, err, "failed to create tilde test file")
 
 	reqWithUnknownFileName, err := createTempFile(
 		fs,
@@ -79,7 +85,7 @@ func TestRequest(t *testing.T) {
 		name string
 		args []string
 		in   io.Reader
-		want map[string]any
+		want []map[string]any
 	}{
 		{
 			name: "by proto",
@@ -92,7 +98,7 @@ func TestRequest(t *testing.T) {
 				"-p",
 				protoFile,
 			},
-			want: map[string]any{"msg": "oops"},
+			want: []map[string]any{{"msg": "oops"}},
 		},
 		{
 			name: "by proto with import all",
@@ -104,7 +110,7 @@ func TestRequest(t *testing.T) {
 				importPath,
 				"--import-all",
 			},
-			want: map[string]any{"msg": "good"},
+			want: []map[string]any{{"msg": "good"}},
 		},
 		{
 			name: "by reflection",
@@ -116,7 +122,7 @@ func TestRequest(t *testing.T) {
 				`{"msg":"hello"}`,
 				"-r",
 			},
-			want: map[string]any{"msg": "hello"},
+			want: []map[string]any{{"msg": "hello"}},
 		},
 		{
 			name: "data from flag with unknown field",
@@ -128,7 +134,7 @@ func TestRequest(t *testing.T) {
 				`{"$schema":"https://example.com/some/schema.json","msg":"with unknown"}`,
 				"-r",
 			},
-			want: map[string]any{"msg": "with unknown"},
+			want: []map[string]any{{"msg": "with unknown"}},
 		},
 		{
 			name: "data from file",
@@ -136,11 +142,11 @@ func TestRequest(t *testing.T) {
 				"echo.EchoService.Echo",
 				"-a",
 				address(insecureSocket),
-				"-d",
-				"@" + requestFileName,
+				"-f",
+				requestFileName,
 				"-r",
 			},
-			want: map[string]any{"msg": "file test"},
+			want: []map[string]any{{"msg": "file test"}},
 		},
 		{
 			name: "data from file with unknown field",
@@ -148,11 +154,23 @@ func TestRequest(t *testing.T) {
 				"echo.EchoService.Echo",
 				"-a",
 				address(insecureSocket),
-				"-d",
-				"@" + reqWithUnknownFileName,
+				"-f",
+				reqWithUnknownFileName,
 				"-r",
 			},
-			want: map[string]any{"msg": "file with unknown"},
+			want: []map[string]any{{"msg": "file with unknown"}},
+		},
+		{
+			name: "data from file with tilde path",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-f",
+				"~/" + tildeTestFileName,
+				"-r",
+			},
+			want: []map[string]any{{"msg": "tilde test"}},
 		},
 		{
 			name: "data from stdin",
@@ -165,7 +183,7 @@ func TestRequest(t *testing.T) {
 				"-r",
 			},
 			in:   strings.NewReader(`{"msg":"stdin test"}`),
-			want: map[string]any{"msg": "stdin test"},
+			want: []map[string]any{{"msg": "stdin test"}},
 		},
 		{
 			name: "data from stdin with unknown field",
@@ -178,7 +196,7 @@ func TestRequest(t *testing.T) {
 				"-r",
 			},
 			in:   strings.NewReader(`{"$schema":"https://example.com/some/schema.json","msg":"stdin with unknown"}`),
-			want: map[string]any{"msg": "stdin with unknown"},
+			want: []map[string]any{{"msg": "stdin with unknown"}},
 		},
 		{
 			name: "empty data outputs template",
@@ -188,7 +206,7 @@ func TestRequest(t *testing.T) {
 				address(insecureSocket),
 				"-r",
 			},
-			want: map[string]any{"msg": ""},
+			want: []map[string]any{{"msg": ""}},
 		},
 		{
 			name: "by proto with config",
@@ -199,7 +217,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"proto config"}`,
 			},
-			want: map[string]any{"msg": "proto config"},
+			want: []map[string]any{{"msg": "proto config"}},
 		},
 		{
 			name: "by proto import all with config",
@@ -210,7 +228,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"proto import all"}`,
 			},
-			want: map[string]any{"msg": "proto import all"},
+			want: []map[string]any{{"msg": "proto import all"}},
 		},
 		{
 			name: "by reflection with config",
@@ -221,7 +239,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"reflection config"}`,
 			},
-			want: map[string]any{"msg": "reflection config"},
+			want: []map[string]any{{"msg": "reflection config"}},
 		},
 		{
 			name: "tls with only root certificate",
@@ -236,7 +254,7 @@ func TestRequest(t *testing.T) {
 				"--cacert",
 				cacert,
 			},
-			want: map[string]any{"msg": "tls"},
+			want: []map[string]any{{"msg": "tls"}},
 		},
 		{
 			name: "tls with server certificates",
@@ -255,7 +273,7 @@ func TestRequest(t *testing.T) {
 				"--key",
 				key,
 			},
-			want: map[string]any{"msg": "tls certs"},
+			want: []map[string]any{{"msg": "tls certs"}},
 		},
 		{
 			name: "tls with server certificates config",
@@ -266,7 +284,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"tls certs config"}`,
 			},
-			want: map[string]any{"msg": "tls certs config"},
+			want: []map[string]any{{"msg": "tls certs config"}},
 		},
 		{
 			name: "package flag specified",
@@ -280,7 +298,7 @@ func TestRequest(t *testing.T) {
 				"--package",
 				"echo",
 			},
-			want: map[string]any{"msg": "package flag"},
+			want: []map[string]any{{"msg": "package flag"}},
 		},
 		{
 			name: "package and service flag specified",
@@ -296,7 +314,7 @@ func TestRequest(t *testing.T) {
 				"--service",
 				"EchoService",
 			},
-			want: map[string]any{"msg": "package and service flags"},
+			want: []map[string]any{{"msg": "package and service flags"}},
 		},
 		{
 			name: "package and service config file specified",
@@ -307,7 +325,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"package and service flags"}`,
 			},
-			want: map[string]any{"msg": "package and service flags"},
+			want: []map[string]any{{"msg": "package and service flags"}},
 		},
 		{
 			name: "web request with config",
@@ -318,7 +336,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"web config"}`,
 			},
-			want: map[string]any{"msg": "web config"},
+			want: []map[string]any{{"msg": "web config"}},
 		},
 		{
 			name: "web request",
@@ -331,7 +349,7 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"web unary"}`,
 			},
-			want: map[string]any{"msg": "web unary"},
+			want: []map[string]any{{"msg": "web unary"}},
 		},
 		{
 			name: "web tls request with config",
@@ -342,29 +360,8 @@ func TestRequest(t *testing.T) {
 				"-d",
 				`{"msg":"web tls config"}`,
 			},
-			want: map[string]any{"msg": "web tls config"},
+			want: []map[string]any{{"msg": "web tls config"}},
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b, err := runRequest(fs, tt.in, tt.args...)
-			require.NoErrorf(t, err, "command failed with output: %s", string(b))
-
-			got := map[string]any{}
-			require.NoError(t, json.Unmarshal(b, &got))
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestRequest_MultipleMessages(t *testing.T) {
-	fs := afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
-
-	tests := []struct {
-		name string
-		args []string
-		want []map[string]any
-	}{
 		{
 			name: "client streaming request format",
 			args: []string{
@@ -392,7 +389,7 @@ func TestRequest_MultipleMessages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, err := runRequest(fs, nil, tt.args...)
+			b, err := runRequest(fs, tt.in, tt.args...)
 			require.NoErrorf(t, err, "command failed with output: %s", string(b))
 
 			got := []map[string]any{}
@@ -506,8 +503,8 @@ func TestRequest_ErrorCases(t *testing.T) {
 				"echo.EchoService.Echo",
 				"-a",
 				address(insecureSocket),
-				"-d",
-				"@/nonexistent/file.json",
+				"-f",
+				"/nonexistent/file.json",
 				"-r",
 			},
 			wantErr: "file does not exist",
@@ -521,6 +518,20 @@ func TestRequest_ErrorCases(t *testing.T) {
 				"-r",
 			},
 			wantErr: "Symbol not found: ..UnknownMethod",
+		},
+		{
+			name: "both data and file flags specified",
+			args: []string{
+				"echo.EchoService.Echo",
+				"-a",
+				address(insecureSocket),
+				"-d",
+				`{"msg":"test"}`,
+				"-f",
+				"/some/file.json",
+				"-r",
+			},
+			wantErr: "only data or file flag is allowed to be set",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
BREAKING CHANGE: "-d @" flag format is no longer supported, -f now accepts files instead without @ prefix